### PR TITLE
Fixing http to support posting of binary data in Buffer and ArrayBuffer

### DIFF
--- a/http.js
+++ b/http.js
@@ -219,7 +219,7 @@ function request(method, url, body, params) {
         }
 
         if (body !== null && body !== undefined) {
-            if (typeof body === 'string') {
+            if (typeof body === 'string' || Buffer.isBuffer(body) || body instanceof ArrayBuffer) {
                 options.body = body;
             } else if (typeof body === 'object' && method === 'POST') {
                 options.body = querystring.stringify(body);


### PR DESCRIPTION
Fix http post and put when sending binary data.

K6 http has the ability to recieve Buffer and ArrayBuffer as body for http requests.
The current implementation of http in node will result in coversion of the binary data to json.
The Fix allow sending the buffer directly to body.